### PR TITLE
Unsupported protocol error

### DIFF
--- a/iot.go
+++ b/iot.go
@@ -109,7 +109,6 @@ func GetRegistryCredentials(registry string, region string, s *Service) (*Regist
 		"region": region, "registry": registry, "project": s.ServiceAccountCredentials.Project,
 	})
 	url := fmt.Sprintf("%s/api/v/1/code/%s/getRegistryCredentials", s.ServiceAccountCredentials.Url, s.ServiceAccountCredentials.SystemKey)
-	fmt.Println(s.ServiceAccountCredentials.SystemKey, registry)
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(requestBody))
 	if err != nil {
 		return nil, err

--- a/iot.go
+++ b/iot.go
@@ -109,6 +109,7 @@ func GetRegistryCredentials(registry string, region string, s *Service) (*Regist
 		"region": region, "registry": registry, "project": s.ServiceAccountCredentials.Project,
 	})
 	url := fmt.Sprintf("%s/api/v/1/code/%s/getRegistryCredentials", s.ServiceAccountCredentials.Url, s.ServiceAccountCredentials.SystemKey)
+	fmt.Println(s.ServiceAccountCredentials.SystemKey, registry)
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(requestBody))
 	if err != nil {
 		return nil, err
@@ -124,11 +125,13 @@ func GetRegistryCredentials(registry string, region string, s *Service) (*Regist
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GetRegistryCredentials HTTP Error %d: %s", resp.StatusCode, string(body))
+	}
 	var credentials RegistryUserCredentials
 	_ = json.Unmarshal(body, &credentials)
-
 	s.RegistryUserCache[cacheKey] = &credentials
-
+	
 	return &credentials, nil
 }
 
@@ -3395,6 +3398,7 @@ func (c *ProjectsLocationsRegistriesDevicesCreateCall) doRequest(alt string) (*h
 	registry := matches["registry"]
 	location := matches["location"]
 	credentials, err := GetRegistryCredentials(registry, location, c.s)
+	fmt.Println(credentials)
 	if err != nil {
 		return nil, err
 	}

--- a/iot.go
+++ b/iot.go
@@ -3397,7 +3397,6 @@ func (c *ProjectsLocationsRegistriesDevicesCreateCall) doRequest(alt string) (*h
 	registry := matches["registry"]
 	location := matches["location"]
 	credentials, err := GetRegistryCredentials(registry, location, c.s)
-	fmt.Println(credentials)
 	if err != nil {
 		return nil, err
 	}

--- a/iot.go
+++ b/iot.go
@@ -2139,6 +2139,7 @@ func (c *ProjectsLocationsRegistriesDeleteCall) doRequest(alt string) (*http.Res
 	}
 	var body io.Reader = nil
 	reqHeaders.Set("ClearBlade-UserToken", c.s.ServiceAccountCredentials.Token)
+	c.urlParams_.Set("name", c.name)
 
 	urls := fmt.Sprintf("%s/api/v/4/webhook/execute/%s/cloudiot", c.s.ServiceAccountCredentials.Url, c.s.ServiceAccountCredentials.SystemKey)
 	urls += "?" + c.urlParams_.Encode()


### PR DESCRIPTION
This issue is a byproduct of the GetRegistryCredentials method not returning an error when there is a non okay http status code. The underlying error is actually because of GetRegistryCredentials wasn't returning an error when it recieved an http error.