### PR TITLE
Fixed lint errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,5 @@
 ---
+version: 2
 output:
   sort-results: true
 issues:
@@ -32,8 +33,8 @@ linters:
   enable:
     - misspell
     - unconvert
-    - gofmt
     - unparam
+#    - gofmt
 #    - nolintlint # RE-ENABLE AFTER THEY FIX GO1.18 STUFF
 #    - maligned
 #    - gocritic

--- a/cblib/gensupport/send.go
+++ b/cblib/gensupport/send.go
@@ -162,7 +162,7 @@ func sendAndRetry(ctx context.Context, client *http.Client, req *http.Request, r
 
 		pause = bo.Pause()
 		if resp != nil && resp.Body != nil {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 		}
 	}
 	return resp, err

--- a/cblib/path_template/path_template.go
+++ b/cblib/path_template/path_template.go
@@ -178,7 +178,7 @@ func (pt *PathTemplate) Match(path string) (map[string]string, error) {
 		paths = paths[length:]
 	}
 	if len(paths) != 0 {
-		return nil, fmt.Errorf("Trailing path %s remains after the matching", strings.Join(paths, "/"))
+		return nil, fmt.Errorf("trailing path %s remains after the matching", strings.Join(paths, "/"))
 	}
 	return values, nil
 }
@@ -423,8 +423,8 @@ func ResolveRelative(basestr, relstr string) string {
 	if afterColonPath != "" {
 		us = fmt.Sprintf("%s:%s", us, afterColonPath)
 	}
-	us = strings.Replace(us, "%7B", "{", -1)
-	us = strings.Replace(us, "%7D", "}", -1)
-	us = strings.Replace(us, "%2A", "*", -1)
+	us = strings.ReplaceAll(us, "%7B", "{")
+	us = strings.ReplaceAll(us, "%7D", "}")
+	us = strings.ReplaceAll(us, "%2A", "*")
 	return us
 }

--- a/cblib/third_party/uritemplates/uritemplates.go
+++ b/cblib/third_party/uritemplates/uritemplates.go
@@ -20,9 +20,9 @@ import (
 )
 
 var (
-	unreserved = regexp.MustCompile("[^A-Za-z0-9\\-._~]")
-	reserved   = regexp.MustCompile("[^A-Za-z0-9\\-._~:/?#[\\]@!$&'()*+,;=]")
-	validname  = regexp.MustCompile("^([A-Za-z0-9_\\.]|%[0-9A-Fa-f][0-9A-Fa-f])+$")
+	unreserved = regexp.MustCompile(`[^A-Za-z0-9\-._~]`)
+	reserved   = regexp.MustCompile(`[^A-Za-z0-9\-._~:/?#[\]@!$&'()*+,;=]`)
+	validname  = regexp.MustCompile(`^([A-Za-z0-9_\.]|%[0-9A-Fa-f][0-9A-Fa-f])+$`)
 	hex        = []byte("0123456789ABCDEF")
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,10 @@
+cloud.google.com/go v0.105.0 h1:DNtEKRBAAzeS4KyIory52wWHuClNaXJ5x1F7xa4q+5Y=
+cloud.google.com/go/longrunning v0.3.0 h1:NjljC+FYPV3uh5/OwWT6pVU+doBqMg2x/rZlE+CamDs=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.7.0 h1:IcsPKeInNvYi7eqSaDjiZqDDKu5rsmunY0Y1YupQSSQ=

--- a/iot.go
+++ b/iot.go
@@ -1108,7 +1108,7 @@ type ListDeviceRegistriesResponse struct {
 // meant to future-proof against the nextPageToken potentially changing from a number to a string
 type ambiguousListDeviceRegistriesResponse struct {
 	DeviceRegistries []*DeviceRegistry `json:"deviceRegistries,omitempty"`
-	NextPageToken interface{} `json:"nextPageToken,omitempty"`
+	NextPageToken    interface{}       `json:"nextPageToken,omitempty"`
 }
 
 func (w *ListDeviceRegistriesResponse) UnmarshalJSON(data []byte) error {
@@ -2667,9 +2667,6 @@ func (c *ProjectsLocationsRegistriesListCall) Do() (*ListDeviceRegistriesRespons
 			Code:   res.StatusCode,
 			Header: res.Header,
 		})
-	}
-	if err != nil {
-		return nil, err
 	}
 	defer res.Body.Close()
 	if err := googleapi.CheckResponse(res); err != nil {


### PR DESCRIPTION
@WorkForPizza ,

To make **golangci-lint run** work I had to change **.golangci.yml**:
1. Add 'version: 2' at the top
2. Comment out 'gofmt' in linters >> enable